### PR TITLE
Integrated auth module from tdamertiradeclient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,15 +17,17 @@ dependencies = [
 
 [[package]]
 name = "attohttpc"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5db1932a9d70d5091139d6b0e04ec6a4d9f9184041c15d71a5ef954cb3c5312"
+checksum = "93610ce1c035e8a273fe56a19852e42798f3c019ca2726e52d2971197f116525"
 dependencies = [
  "flate2",
  "http",
  "log",
  "native-tls",
  "openssl",
+ "serde",
+ "serde_urlencoded",
  "url",
 ]
 
@@ -109,6 +111,12 @@ checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "dtoa"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
 name = "flate2"
@@ -409,6 +417,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "serde",
+ "url",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,7 +442,7 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "tdacli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "tdameritradeclient",
@@ -430,11 +450,12 @@ dependencies = [
 
 [[package]]
 name = "tdameritradeclient"
-version = "0.1.1"
-source = "git+https://github.com/jbertovic/tdameritradeclient.git?tag=v0.1.1#57d22748982485a4e0e917d63af36ace43485209"
+version = "0.2.0"
+source = "git+https://github.com/jbertovic/tdameritradeclient.git?tag=v0.2.0#17ab1aa074ad840fdb0c5497ca50b2ea965df00e"
 dependencies = [
  "attohttpc",
  "serde_json",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,8 +450,8 @@ dependencies = [
 
 [[package]]
 name = "tdameritradeclient"
-version = "0.2.0"
-source = "git+https://github.com/jbertovic/tdameritradeclient.git?tag=v0.2.0#17ab1aa074ad840fdb0c5497ca50b2ea965df00e"
+version = "0.2.1"
+source = "git+https://github.com/jbertovic/tdameritradeclient.git?tag=v0.2.1#c86666045979a510b4009d508bfc983f36057a9a"
 dependencies = [
  "attohttpc",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tdameritradeclient = { git = "https://github.com/jbertovic/tdameritradeclient.git", tag = "v0.2.0" }
+tdameritradeclient = { git = "https://github.com/jbertovic/tdameritradeclient.git", tag = "v0.2.1" }
 clap = "2.33"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "tdacli"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Jas Bertovic <jas@bertovic.net>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tdameritradeclient = { git = "https://github.com/jbertovic/tdameritradeclient.git", tag = "v0.1.1" }
+tdameritradeclient = { git = "https://github.com/jbertovic/tdameritradeclient.git", tag = "v0.2.0" }
 clap = "2.33"

--- a/Readme.md
+++ b/Readme.md
@@ -65,4 +65,4 @@ A valid token must be set in env variable: TDAUTHTOKEN.
 
 - [ ] add option for date calculations on History epoch data stamps
 - [ ] Consider adding date conversion using chrono package
-- [ ] once orders are complete on [TDAClient](https://github.com/jbertovic/tdameritradeclient) than to new subcommand
+- [ ] orders - adding, deleting, listing

--- a/Readme.md
+++ b/Readme.md
@@ -1,16 +1,18 @@
 ## TDACLI
 
-A simple CLI wrapper around my tdameritradeclient library.  You will need to set the token in an environment variable called `TDAUTHTOKEN`.  You can go on [developer.tdameritrade.com](http://developer.tdameritrade.com) to see how to manually create a valid token.
+A simple CLI wrapper around my tdameritradeclient library. For help enter `tdacli --help`.  This will give you access to help and further subcommands.
 
-For help enter `tdacli --help`.  This will give you access to help and further subcommands.
+Current subcommands are: quote, history, optionchain, userprincipals, account, auth, refresh, weblink. See below for description on output of `tdaci --help` in the CLI Commands section
 
-Current subcommands are: quote, history, optionchain, userprincipals, account.
-
+Environmental Variable Requirements:
+- `TDAUTHTOKEN` on subcommands: account, history, optionchain, quote, userprincipals
+- `TDREFRESHTOKEN` on subcommands: refresh
+- `TDCODE` on subcommand: auth
+- No Env Variable on subcommand: weblink
 
 ## Example
 
-an example usage piped into jq running on linux
-
+an example usage piped into jq running on linux.  Assumes `TDAUTHTOKEN` env variable holds valid token.
 
 ```
 > tdacli quote SPY,INTC,VNQ | jq '.[] | {symbol, mark, bidPrice, askPrice}'
@@ -34,11 +36,61 @@ an example usage piped into jq running on linux
 }
 ```
 
-## CLI commands
+## Authorization from scratch
+
+### 1) Fetch code using weblink
+Use the `weblink` subcommand along with registered app on developer.tdameritrade.com to get an authorization link. When you register an app you will have a `consumer_key` (referred through out as clientid) and a `redirect_uri`. I recommend using a redirecturi that is your localhost (`https://127.0.0.1:8080/`).  This way you can copy the returned code directly from the query bar in the browser.  The below Consumer Key is only an example.  
 
 ```
->tdacli --help
-TDAmeritrade API CLI 0.1.0
+> tdacli weblink J3ROAVSNNFTLC9RJE4BD2DO2WJABCDEF https://127.0.0.1:8080/
+https://auth.tdameritrade.com/auth?response_type=code&redirect_uri=https%3A%2F%2F127.0.0.1%3A8080%2F&client_id=J3ROAVSNNFTLC9RJE4BD2DO2WJ9JE4DG%40AMER.OAUTHAP
+
+```
+
+Visit this link and authorize your access directly with TDameritrade.  You will receive the code in the query bar.  Only copy the encoded string after `code=`.  Assign this to the environment variable `TDCODE`.
+
+
+
+### 2) Use code to retrieve token and refresh_token
+
+From step 1 above with `TDCODE` env variable assigned.
+
+```
+> tdacli auth J3ROAVSNNFTLC9RJE4BD2DO2WJABCDEF https://127.0.0.1:8080/
+{"Token": "UZfU1e9dhw9zdq26+vJa1tERNhfaa4lFXqgfzeVW+HOEdRKHSDvnq0lepMd.....long string truncated",
+"Refresh": "a1tERNhfaa4lFXqgfzeVW+HOEdRKHSDvnq0lepMdvJa1tERNhfa....long string truncated"}
+```
+
+Assign the Refresh token to TDREFRESHTOKEN and the Token to TDAUTHTOKEN.  You can go ahead and run any of the other subcommands with TDAUTHTOKEN set.
+
+A refresh token lasts for 90 days and can be used to get a valid token to access tdameritrade API.  The token is only valid for 30 min before expiring.  Reuse the same or new refresh token to renew.
+
+
+### 3) Use refresh to maintain an active token
+
+Assumes REFRESHTOKEN is set and valid.
+
+```
+> tdacli refresh J3ROAVSNNFTLC9RJE4BD2DO2WJABCDEF
+zdq26+vJaNhfaa4lFXqgfzeVW+HOEdRKHSDzdq26+vJa1tERNhfaa4lFXqgfzeVW+HOEdRKHSDzdq26+vJa1tERNhfaa4...long string truncated
+```
+
+Use the returned value to set TDAUTHTOKEN.
+
+In bash you can automate this with:
+```
+export TDAUTHTOKEN=$(tdacli refresh J3ROAVSNNFTLC9RJE4BD2DO2WJABCDEF)
+```
+
+Not sure how to do this in windows?  Please DM me if you know.
+
+## CLI Commands
+
+### Output of main help
+
+```
+> tdacli --help
+TDAmeritrade API CLI 0.2.0
 Command Line Interface into tdameritradeclient rust library
 
 USAGE:
@@ -50,14 +102,53 @@ FLAGS:
 
 SUBCOMMANDS:
     account           Retrieve account information for <account_id>
+    auth              Retrieves refresh_token using authorization_code grant type
     help              Prints this message or the help of the given subcommand(s)
     history           Retrieve history for one <symbol>.
     optionchain       Retrieve option chain for one <symbol>
     quote             Retrieve quotes for requested symbols
+    refresh           Fetch valid token or renew refresh_token using a refresh_token grant type
     userprincipals    Retrieves User Principals
+    weblink           Gives you the url to get authorization code from TDAmeritrade
 
-A valid token must be set in env variable: TDAUTHTOKEN.
+Check env variable requirements for each subcommand.
+Token can be retrieved using 'refresh' subcommand if you have a valid refresh_token.
+Token can also be issued by using 'weblink' subcommand first to retrieve 'authorization_code'
+and 'auth' subcommand to issue new token and refresh_token.
 '*' indicates default value in subcommand help information.
+```
+
+### history help
+Included one help output of subcommand as an example.  All subcommands have `--help` option to help understand usage.
+
+```
+> tdacli history --help
+tdacli-history
+Retrieve history for one <symbol>.
+
+USAGE:
+    tdacli history [OPTIONS] <symbol> [ARGS]
+
+FLAGS:
+    -h, --help    Prints help information
+
+OPTIONS:
+        --freq <freq>            Defines number of freq_types to show: minute: 1*,5,10,15,30 | daily: 1* | weekly: 1* |
+                                 monthly: 1*
+        --ftype <freq_type>      Defines freq of new candle by period_type: day: minute* | month: daily, weekly* | year:
+                                 daily, weekly, monthly* | ytd: daily, weekly*
+        --period <period>        Defines number of periods to show; day: 1,2,3,4,5,10* | month: 1*,2,3,6 | year:
+                                 1*,2,3,5,10,15,20 | ytd: 1*
+        --ptype <period_type>    Defines period type: day, month, year, ytd
+
+ARGS:
+    <symbol>       Symbol of instrument.
+    <startdate>    Defines start date in epoch format. <period> should not be provided
+    <enddate>      Defines end date epoch format. Default is previous trading day.
+
+Think of the frequency as the size of a candle on the chart or how to divide the ticks.
+and the period as the term or total length of the history.
+'*' indicates default value.
 ```
 
 
@@ -66,3 +157,4 @@ A valid token must be set in env variable: TDAUTHTOKEN.
 - [ ] add option for date calculations on History epoch data stamps
 - [ ] Consider adding date conversion using chrono package
 - [ ] orders - adding, deleting, listing
+- [ ] potential to integrate a json query language on output

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,0 +1,12 @@
+use clap::ArgMatches;
+use tdameritradeclient::auth::getcodeweblink;
+
+pub fn weblink(args: &ArgMatches) {
+    println!("{}", 
+        getcodeweblink(args.value_of("clientid").unwrap(), args.value_of("redirect").unwrap()));
+}
+
+pub fn auth(args: &ArgMatches) {
+    println!("{}", 
+        getcodeweblink(args.value_of("clientid").unwrap(), args.value_of("redirect").unwrap()));
+}

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -10,3 +10,8 @@ pub fn auth(args: &ArgMatches) {
     println!("{}", 
         getcodeweblink(args.value_of("clientid").unwrap(), args.value_of("redirect").unwrap()));
 }
+
+pub fn refresh(args: &ArgMatches) {
+    println!("{}", 
+        getcodeweblink(args.value_of("clientid").unwrap(), args.value_of("redirect").unwrap()));
+}

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,17 +1,43 @@
 use clap::ArgMatches;
-use tdameritradeclient::auth::getcodeweblink;
+use std::env;
+use tdameritradeclient::auth::{getcodeweblink, gettoken_fromrefresh, getrefresh_fromrefresh, gettoken_fromcode};
 
+/// Create a link to use to get an authorization_code from tdameritrade
+/// Code can be used to fetch a token and refresh token in the `auth` subcommand
 pub fn weblink(args: &ArgMatches) {
     println!("{}", 
         getcodeweblink(args.value_of("clientid").unwrap(), args.value_of("redirect").unwrap()));
 }
-
+/// Fetch updated `token` or `refresh_token` from a current `refresh_token`
 pub fn auth(args: &ArgMatches) {
-    println!("{}", 
-        getcodeweblink(args.value_of("clientid").unwrap(), args.value_of("redirect").unwrap()));
+    let code = env::var("TDCODE").expect("Authorization CODE is missing inside env variable TDCODE");
+    match args.value_of("clientid") {
+        Some(clientid) => {
+            match args.value_of("redirect") {
+                Some(redirect) => {
+                    let decoded = !args.is_present("decoded");
+                    println!("{}", gettoken_fromcode(&code, clientid, redirect, decoded));
+                },
+                None => println!("{{ \"error\": \"Missing redirect\"}}"),
+            }
+        },
+        None => println!("{{ \"error\": \"Missing clientid\"}}"),
+    }
 }
-
+/// Fetch updated `token` or `refresh_token` from a current `refresh_token`
 pub fn refresh(args: &ArgMatches) {
-    println!("{}", 
-        getcodeweblink(args.value_of("clientid").unwrap(), args.value_of("redirect").unwrap()));
+    let rtoken = env::var("TDREFRESHTOKEN").expect("Refresh_token is missing inside env variable TDREFRESHTOKEN");
+    match args.value_of("clientid") {
+        Some(clientid) => {
+            // do i need to renew refresh or only token?
+            // need to update tdameritradeclient to include getrefresh_fromrefresh()
+            let token = if args.is_present("updaterefresh") {
+                gettoken_fromrefresh(&rtoken, clientid)
+            } else {
+                getrefresh_fromrefresh(&rtoken, clientid)
+            };
+            println!("{}", token);
+        }
+        None => println!("{{ \"error\": \"Missing clientid\"}}"),
+    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,29 +5,48 @@ pub fn cli_matches<'a>() -> ArgMatches<'a> {
         .version(crate_version!())
         .setting(AppSettings::VersionlessSubcommands)
         .about("Command Line Interface into tdameritradeclient rust library")
-        .arg(
-            Arg::with_name("refresh")
-            .short("r")
-            .help("Use env variable: TDREFRESHTOKEN as a refresh token.")
-        )
-        .arg(
-            Arg::with_name("printrefresh")
-            .short("p")
-            .help("Print current token")
-        )
-        .arg(
-            Arg::with_name("updaterefresh")
-            .short("u")
-            .help("Update refresh token. Only with '-r'")
-        )
-        .arg(
-            Arg::with_name("assignvar")
-            .short("a")
-            .help("Assign updated tokens to variables: TDAUTHTOKEN and TDREFRESHTOKEN. Only with '-r'")
+        .subcommand(
+            SubCommand::with_name("refresh")
+            .about("Valid token or renew refresh_token using a refresh_token grant type")
+            .arg(
+                Arg::with_name("printrefresh")
+                .short("r")
+                .help("Print refresh token")
+            )
+            .arg(
+                Arg::with_name("printtoken")
+                .short("p")
+                .help("Print current token")
+            )
+            .arg(
+                Arg::with_name("updaterefresh")
+                .short("u")
+                .help("Update refresh_token.  Otherwise only token vill be updated.")
+            )
+            .arg(
+                Arg::with_name("assignvar")
+                .short("a")
+                .help("Assign updated tokens to env variables: TDAUTHTOKEN and TDREFRESHTOKEN.")
+            )
+            .arg(
+                Arg::with_name("clientid")
+                .takes_value(true)
+                .help("Also known as consumer key as registered at developer.tdameritrade.com")
+            )
         )
         .subcommand(
             SubCommand::with_name("auth")
             .arg(
+                Arg::with_name("decoded")
+                .short("d")
+                .help("Code is decoded and NOT url encoded. Do NOT use this if copied from browser window.")
+            )
+            .arg(
+                Arg::with_name("assignvar")
+                .short("a")
+                .help("Assign updated tokens to variables: TDAUTHTOKEN and TDREFRESHTOKEN")
+            )
+                .arg(
                 Arg::with_name("clientid")
                 .takes_value(true)
                 .required(true)
@@ -39,8 +58,8 @@ pub fn cli_matches<'a>() -> ArgMatches<'a> {
                 .required(true)
                 .help("Redirect URI as registered at developer.tdameritrade.com")
             )
-            .about("Valid token and refresh_token from authorization_code")
-            .after_help("NOTE: code must be set in env variable: TDCODE")
+            .about("Valid token and refresh_token using authorization_code grant type")
+            .after_help("NOTE: code must be set in env variable: TDCODE. See 'weblink' subcommand to retrieve code.")
         )
         .subcommand(
             SubCommand::with_name("weblink")
@@ -225,7 +244,9 @@ pub fn cli_matches<'a>() -> ArgMatches<'a> {
                 .after_help("'*' indicates default value.")
             )
         .after_help("A valid token must be set in env variable: TDAUTHTOKEN.\r\n\
-            If '-r' flag is used than env variable: TDREFRESHTOKEN can be used instead.\r\n\
+            Token can be retrieved using 'refresh' subcommand if you have a valid refresh_token.\r\n\
+            Token can also be issued by using 'weblink' subcommand first to retrieve 'authorization_code'\r\n\
+             and 'auth' subcommand to issue new token and refresh_token.\r\n\
             '*' indicates default value in subcommand help information.")
         .get_matches()
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::{App, Arg, SubCommand, ArgMatches, AppSettings, ArgGroup};
+use clap::{App, AppSettings, Arg, ArgGroup, ArgMatches, SubCommand};
 
 pub fn cli_matches<'a>() -> ArgMatches<'a> {
     App::new("TDAmeritrade API CLI")
@@ -39,7 +39,7 @@ pub fn cli_matches<'a>() -> ArgMatches<'a> {
                 .required(true)
                 .help("Redirect URI as registered at developer.tdameritrade.com")
             )
-            .about("Valid token and refresh_token using authorization_code grant type")
+            .about("Retrieves refresh_token using authorization_code grant type")
             .after_help("NOTE: code must be set in env variable: TDCODE. See 'weblink' subcommand to retrieve code.")
         )
         .subcommand(
@@ -58,7 +58,10 @@ pub fn cli_matches<'a>() -> ArgMatches<'a> {
             )
             .about("Gives you the url to get authorization code from TDAmeritrade")
         )
-        .subcommand(SubCommand::with_name("userprincipals").about("Retrieves User Principals"))
+        .subcommand(SubCommand::with_name("userprincipals")
+            .about("Retrieves User Principals")
+            .after_help("NOTE: Token must be set in env variable: TDAUTHTOKEN.")
+        )
         .subcommand(
             SubCommand::with_name("account")
                 .about("Retrieve account information for <account_id>")
@@ -78,7 +81,8 @@ pub fn cli_matches<'a>() -> ArgMatches<'a> {
                         .short("o")
                         .help("includes account orders")
                 )
-        )
+                .after_help("NOTE: Token must be set in env variable: TDAUTHTOKEN.")
+            )
         .subcommand(
             SubCommand::with_name("quote")
                 .about("Retrieve quotes for requested symbols")
@@ -86,7 +90,8 @@ pub fn cli_matches<'a>() -> ArgMatches<'a> {
                     .required(true)
                     .help("Retrieves quotes of supplied <symbols> in format \"sym1,sym2,sym3\""
                 ))
-        )
+                .after_help("NOTE: Token must be set in env variable: TDAUTHTOKEN.")
+            )
         .subcommand(
             SubCommand::with_name("history")
                 .about("Retrieve history for one <symbol>.")
@@ -130,7 +135,8 @@ pub fn cli_matches<'a>() -> ArgMatches<'a> {
                         .takes_value(true)
                         .help("Defines end date epoch format. Default is previous trading day.")
                 )
-                .after_help("Think of the frequency as the size of a candle on the chart or how to divide the ticks. \n\
+                .after_help("NOTE: Token must be set in env variable: TDAUTHTOKEN. \n\r\
+                                Think of the frequency as the size of a candle on the chart or how to divide the ticks. \n\
                                 and the period as the term or total length of the history. \n\
                                 '*' indicates default value.")
             )
@@ -222,9 +228,10 @@ pub fn cli_matches<'a>() -> ArgMatches<'a> {
                 .group(ArgGroup::with_name("option_type")
                     .args(&["typeS", "typeNS"])
                 )
-                .after_help("'*' indicates default value.")
+                .after_help("NOTE: Token must be set in env variable: TDAUTHTOKEN.\n\r\
+                                    '*' indicates default value.")
             )
-        .after_help("A valid token must be set in env variable: TDAUTHTOKEN.\r\n\
+        .after_help("Check env variable requirements for each subcommand.\r\n\
             Token can be retrieved using 'refresh' subcommand if you have a valid refresh_token.\r\n\
             Token can also be issued by using 'weblink' subcommand first to retrieve 'authorization_code'\r\n\
              and 'auth' subcommand to issue new token and refresh_token.\r\n\

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,32 +7,18 @@ pub fn cli_matches<'a>() -> ArgMatches<'a> {
         .about("Command Line Interface into tdameritradeclient rust library")
         .subcommand(
             SubCommand::with_name("refresh")
-            .about("Valid token or renew refresh_token using a refresh_token grant type")
-            .arg(
-                Arg::with_name("printrefresh")
-                .short("r")
-                .help("Print refresh token")
-            )
-            .arg(
-                Arg::with_name("printtoken")
-                .short("p")
-                .help("Print current token")
-            )
+            .about("Fetch valid token or renew refresh_token using a refresh_token grant type")
             .arg(
                 Arg::with_name("updaterefresh")
                 .short("u")
                 .help("Update refresh_token.  Otherwise only token vill be updated.")
             )
             .arg(
-                Arg::with_name("assignvar")
-                .short("a")
-                .help("Assign updated tokens to env variables: TDAUTHTOKEN and TDREFRESHTOKEN.")
-            )
-            .arg(
                 Arg::with_name("clientid")
                 .takes_value(true)
                 .help("Also known as consumer key as registered at developer.tdameritrade.com")
             )
+            .after_help("NOTE: refresh_token must be set in env variable: TDREFRESHTOKEN.")
         )
         .subcommand(
             SubCommand::with_name("auth")
@@ -40,11 +26,6 @@ pub fn cli_matches<'a>() -> ArgMatches<'a> {
                 Arg::with_name("decoded")
                 .short("d")
                 .help("Code is decoded and NOT url encoded. Do NOT use this if copied from browser window.")
-            )
-            .arg(
-                Arg::with_name("assignvar")
-                .short("a")
-                .help("Assign updated tokens to variables: TDAUTHTOKEN and TDREFRESHTOKEN")
             )
                 .arg(
                 Arg::with_name("clientid")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,6 +5,49 @@ pub fn cli_matches<'a>() -> ArgMatches<'a> {
         .version(crate_version!())
         .setting(AppSettings::VersionlessSubcommands)
         .about("Command Line Interface into tdameritradeclient rust library")
+        .arg(
+            Arg::with_name("refresh")
+            .short("r")
+            .help("Use env variable: TDREFRESHTOKEN as a refresh token.")
+        )
+        .arg(
+            Arg::with_name("printrefresh")
+            .short("p")
+            .help("Print current token")
+        )
+        .subcommand(
+            SubCommand::with_name("auth")
+            .arg(
+                Arg::with_name("clientid")
+                .takes_value(true)
+                .required(true)
+                .help("Also known as consumer key as registered at developer.tdameritrade.com")
+            )
+            .arg(
+                Arg::with_name("redirect")
+                .takes_value(true)
+                .required(true)
+                .help("Redirect URI as registered at developer.tdameritrade.com")
+            )
+            .about("Refresh token from refresh_token or authorization_code\r\n\
+            NOTE: code must be set in env variable: TDCODE")
+        )
+        .subcommand(
+            SubCommand::with_name("weblink")
+            .arg(
+                Arg::with_name("clientid")
+                .takes_value(true)
+                .required(true)
+                .help("Also known as consumer key as registered at developer.tdameritrade.com")
+            )
+            .arg(
+                Arg::with_name("redirect")
+                .takes_value(true)
+                .required(true)
+                .help("Redirect URI as registered at developer.tdameritrade.com")
+            )
+            .about("Gives you the url to get authorization code from TDAmeritrade")
+        )
         .subcommand(SubCommand::with_name("userprincipals").about("Retrieves User Principals"))
         .subcommand(
             SubCommand::with_name("account")
@@ -171,6 +214,8 @@ pub fn cli_matches<'a>() -> ArgMatches<'a> {
                 )
                 .after_help("'*' indicates default value.")
             )
-        .after_help("A valid token must be set in env variable: TDAUTHTOKEN.\r\n'*' indicates default value in subcommand help information.")
+        .after_help("A valid token must be set in env variable: TDAUTHTOKEN.\r\n\
+            If '-r' flag is used than env variable: TDREFRESHTOKEN can be used instead.\r\n\
+            '*' indicates default value in subcommand help information.")
         .get_matches()
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,6 +15,16 @@ pub fn cli_matches<'a>() -> ArgMatches<'a> {
             .short("p")
             .help("Print current token")
         )
+        .arg(
+            Arg::with_name("updaterefresh")
+            .short("u")
+            .help("Update refresh token. Only with '-r'")
+        )
+        .arg(
+            Arg::with_name("assignvar")
+            .short("a")
+            .help("Assign updated tokens to variables: TDAUTHTOKEN and TDREFRESHTOKEN. Only with '-r'")
+        )
         .subcommand(
             SubCommand::with_name("auth")
             .arg(
@@ -29,8 +39,8 @@ pub fn cli_matches<'a>() -> ArgMatches<'a> {
                 .required(true)
                 .help("Redirect URI as registered at developer.tdameritrade.com")
             )
-            .about("Refresh token from refresh_token or authorization_code\r\n\
-            NOTE: code must be set in env variable: TDCODE")
+            .about("Valid token and refresh_token from authorization_code")
+            .after_help("NOTE: code must be set in env variable: TDCODE")
         )
         .subcommand(
             SubCommand::with_name("weblink")

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,22 +35,43 @@ fn main() {
     //TODO: orders: add (need to determine how to specify order desc json)
     //TODO: orders: delete
 
-    // TODO: CHECK for proper token setup when running
-    // Either TDAUTHTOKEN exists or TDREFRESHTOKEN with subcommands `auth` and `refresh` or NOTHING with `weblink`
-    let c = TDAClient::new(env::var("TDAUTHTOKEN")
-    .expect("Token is missing inside env variable TDAUTHTOKEN"));
-
     match matches.subcommand() {
-        ("weblink", Some(sub_m)) => auth::weblink(&sub_m),
-        ("userprincipals", Some(_)) => account::userprincipals(&c),
-        ("account", Some(sub_m)) => account::account(&c, &sub_m),
-        ("quote", Some(sub_m)) => quote::quote(&c, sub_m),
-        ("history", Some(sub_m)) => quote::history(&c, sub_m),
-        ("optionchain", Some(sub_m)) => quote::optionchain(&c, sub_m),
-        ("auth", Some(sub_m)) => auth::auth(sub_m),
-        ("refresh", Some(sub_m)) => auth::refresh(sub_m),
-        //order
-        _ => {}
+        (cmd, Some(sub_m)) => {
+            match cmd {
+
+                // relies on NO Env Variables
+                "weblink" => auth::weblink(&sub_m),
+
+                // relies on env variable TDREFRESHTOKEN
+                "refresh" => {
+                    let refresh = env::var("TDREFRESHTOKEN")
+                        .expect("Token is missing inside env variable TDREFRESHTOKEN");
+                    auth::refresh(sub_m, refresh);
+                    }
+
+                // relies on env variable TDCODE
+                "auth" => {
+                    let code = env::var("TDCODE")
+                        .expect("Code is missing inside env variable TDCODE");
+                    auth::auth(sub_m, code);
+                    }
+
+                // relies on env variable TDAUTHTOKEN and tdameritradeclient::TDClient
+                _ => {
+                    let c = TDAClient::new(env::var("TDAUTHTOKEN")
+                        .expect("Token is missing inside env variable TDAUTHTOKEN"));
+                    match cmd {
+                        "userprincipals" => account::userprincipals(&c),
+                        "account" => account::account(&c, &sub_m),
+                        "quote" => quote::quote(&c, sub_m),
+                        "history" => quote::history(&c, sub_m),
+                        "optionchain" => quote::optionchain(&c, sub_m),
+                        _ => {},
+                    }
+                }
+            }
+        }
+        _ => {println!("Subcommand must be specified.  For more information try --help")}
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,13 +30,13 @@ use tdameritradeclient::TDAClient;
 fn main() {
     let matches = cli::cli_matches();
     
-    //TODO: add refresh subcommand
-    //TODO: refresh: option only to print refresh or token but NOT both
-    //TODO: refresh: able to update either token or both tokens
-    //TODO: refresh: able to assign to env variables
     //TODO: add orders subcommand
     //TODO: orders: output filled, working, all
+    //TODO: orders: add (need to determine how to specify order desc json)
+    //TODO: orders: delete
 
+    // TODO: CHECK for proper token setup when running
+    // Either TDAUTHTOKEN exists or TDREFRESHTOKEN with subcommands `auth` and `refresh` or NOTHING with `weblink`
     let c = TDAClient::new(env::var("TDAUTHTOKEN")
     .expect("Token is missing inside env variable TDAUTHTOKEN"));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ extern crate clap;
 pub mod cli;
 pub mod account;
 pub mod quote;
+pub mod auth;
 
 use std::env;
 use tdameritradeclient::TDAClient;
@@ -33,11 +34,15 @@ fn main() {
         .expect("Token is missing inside env variable TDAUTHTOKEN"));
 
     match matches.subcommand() {
+        ("weblink", Some(sub_m)) => auth::weblink(&sub_m),
         ("userprincipals", Some(_)) => account::userprincipals(&c),
         ("account", Some(sub_m)) => account::account(&c, &sub_m),
         ("quote", Some(sub_m)) => quote::quote(&c, sub_m),
         ("history", Some(sub_m)) => quote::history(&c, sub_m),
         ("optionchain", Some(sub_m)) => quote::optionchain(&c, sub_m),
+        ("auth", Some(sub_m)) => auth::auth(sub_m),
+        //NOT YET IMPLEMENTED
+        //order
         _ => {}
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,9 +29,16 @@ use tdameritradeclient::TDAClient;
 
 fn main() {
     let matches = cli::cli_matches();
-        
+    
+    //TODO: add refresh subcommand
+    //TODO: refresh: option only to print refresh or token but NOT both
+    //TODO: refresh: able to update either token or both tokens
+    //TODO: refresh: able to assign to env variables
+    //TODO: add orders subcommand
+    //TODO: orders: output filled, working, all
+
     let c = TDAClient::new(env::var("TDAUTHTOKEN")
-        .expect("Token is missing inside env variable TDAUTHTOKEN"));
+    .expect("Token is missing inside env variable TDAUTHTOKEN"));
 
     match matches.subcommand() {
         ("weblink", Some(sub_m)) => auth::weblink(&sub_m),
@@ -41,7 +48,7 @@ fn main() {
         ("history", Some(sub_m)) => quote::history(&c, sub_m),
         ("optionchain", Some(sub_m)) => quote::optionchain(&c, sub_m),
         ("auth", Some(sub_m)) => auth::auth(sub_m),
-        //NOT YET IMPLEMENTED
+        ("refresh", Some(sub_m)) => auth::refresh(sub_m),
         //order
         _ => {}
     }


### PR DESCRIPTION
Can now use client to create new token from either refresh_token or code.  Added weblink option that gives the correct web link to tdameritrade for authorization_code.  Refactored code a bit in main.